### PR TITLE
pcache: add default error handler for CacheManager

### DIFF
--- a/clouway-pcache-client-gae/src/main/java/com/clouway/api/pcache/extensions/gae/GaeCacheManagerFactory.java
+++ b/clouway-pcache-client-gae/src/main/java/com/clouway/api/pcache/extensions/gae/GaeCacheManagerFactory.java
@@ -1,6 +1,8 @@
 package com.clouway.api.pcache.extensions.gae;
 
 import com.clouway.api.pcache.CacheManager;
+import com.google.appengine.api.memcache.ErrorHandlers;
+import com.google.appengine.api.memcache.MemcacheService;
 import com.google.appengine.api.memcache.MemcacheServiceFactory;
 
 /**
@@ -9,7 +11,9 @@ import com.google.appengine.api.memcache.MemcacheServiceFactory;
 public final class GaeCacheManagerFactory {
 
   public static CacheManager create() {
-    return new GAECacheManager(MemcacheServiceFactory.getMemcacheService(), new GAECacheExceptionTranslator());
+    MemcacheService memcacheService = MemcacheServiceFactory.getMemcacheService();
+    memcacheService.setErrorHandler(ErrorHandlers.getDefault());
+    return new GAECacheManager(memcacheService, new GAECacheExceptionTranslator());
   }
 }
 


### PR DESCRIPTION
Seting a default error handler for the CacheManager so that when errors happend they will be treated as a memcache miss 