### PR TITLE
pcache: fixing bulk get operation

### DIFF
--- a/clouway-pcache-client-gae/src/main/java/com/clouway/api/pcache/extensions/gae/GAECacheManager.java
+++ b/clouway-pcache-client-gae/src/main/java/com/clouway/api/pcache/extensions/gae/GAECacheManager.java
@@ -111,7 +111,7 @@ import java.util.logging.Logger;
         MatchResult<T> result = getAll(keys, clazz);
 
         output.addAll(result.getHits());
-        output.addAll(missedHitsProvider.get(result.getMissedKeys()));
+        if(result.hasMissedKeys()) output.addAll(missedHitsProvider.get(result.getMissedKeys()));
 
         return output;
     }

--- a/clouway-pcache-client-testing/src/main/java/com/clouway/api/pcache/testing/CacheManagerContract.java
+++ b/clouway-pcache-client-testing/src/main/java/com/clouway/api/pcache/testing/CacheManagerContract.java
@@ -229,6 +229,18 @@ public abstract class CacheManagerContract {
     assertThat(result.getHits().get(0), is(equalTo(person)));
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void doNotCallProviderIfThereIsNoMissedKeys() {
+    cacheManager.put("::key1::", "::value1::");
+
+    final MissedHitsProvider<String> func = context.mock(MissedHitsProvider.class);
+
+    List<String> result = cacheManager.getAll(Arrays.asList("::key1::"), String.class, func);
+
+    assertThat(result, containsInAnyOrder("::value1::"));
+  }
+
   protected abstract CacheManager createCacheManager();
 }
 

--- a/clouway-pcache-client-testing/src/main/java/com/clouway/api/pcache/testing/InMemoryCacheManager.java
+++ b/clouway-pcache-client-testing/src/main/java/com/clouway/api/pcache/testing/InMemoryCacheManager.java
@@ -104,7 +104,7 @@ public class InMemoryCacheManager implements CacheManager {
     MatchResult result = getAll(keys, clazz);
 
     output.addAll(result.getHits());
-    output.addAll(missedHitsProvider.get(result.getMissedKeys()));
+    if(result.hasMissedKeys()) output.addAll(missedHitsProvider.get(result.getMissedKeys()));
 
     return output;
   }


### PR DESCRIPTION
Added check for getAll with MissedHitsProvider.
When there is no missed keys the provider was called with empty list.