### PR TITLE
pcache: adding prefix to bulk get with missed hits provider

### DIFF
--- a/clouway-pcache-client-core/src/main/java/com/clouway/api/pcache/CacheManager.java
+++ b/clouway-pcache-client-core/src/main/java/com/clouway/api/pcache/CacheManager.java
@@ -46,19 +46,21 @@ public interface CacheManager {
     /**
      * Gets a list of objects from the cache by their keys
      *
+     * @param prefix used with the keys for lookup in the cache
      * @param keys the keys of desired objects
+     * @param clazz the class of the result
+     * @return object representing the work done
+     */
+   <V> MatchResult<V> getAll(String prefix, List<String> keys, Class<V> clazz);
+
+    /**
+     * Gets a list of objects from the cache by their keys
+     *
+     * @param keys the keys of desired objects
+     * @param clazz the class of the result
      * @return object representing the work done
      */
    <V> MatchResult<V> getAll(List<String> keys, Class<V> clazz);
-
-    /**
-     * Gets a list with cached objects by their keys and get missed from function
-     *
-     * @param keys the keys of desired objects
-     * @param missedHitsProvider implementation of the MissedHitsProvider interface
-     * @return list of objects
-     */
-   <T> List<T> getAll(List<String> keys, Class<T> clazz, MissedHitsProvider<T> missedHitsProvider);
 
    /**
     * Removes an object from the cache by it's key

--- a/clouway-pcache-client-testing/src/main/java/com/clouway/api/pcache/testing/InMemoryCacheManager.java
+++ b/clouway-pcache-client-testing/src/main/java/com/clouway/api/pcache/testing/InMemoryCacheManager.java
@@ -76,6 +76,29 @@ public class InMemoryCacheManager implements CacheManager {
 
   @Override
   @SuppressWarnings("unchecked")
+  public <V> MatchResult<V> getAll(String prefix, List<String> keys, Class<V> clazz) {
+    List<V> hits = new LinkedList<>();
+    List<String> missed = new LinkedList<>();
+
+    for(String key: keys) {
+      TimeValue timeValue = values.get(prefix+key);
+
+      if(timeValue != null) {
+        try {
+          hits.add(clazz.cast(timeValue.value));
+        } catch(ClassCastException e) {
+          missed.add(key);
+        }
+      } else {
+        missed.add(key);
+      }
+    }
+
+    return new MatchResult(hits, missed);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
   public <V> MatchResult<V> getAll(List<String> keys, Class<V> clazz) {
     List<V> hits = new LinkedList<>();
     List<String> missed = new LinkedList<>();
@@ -95,18 +118,6 @@ public class InMemoryCacheManager implements CacheManager {
     }
 
     return new MatchResult(hits, missed);
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public <T> List<T> getAll(List<String> keys, Class<T> clazz, MissedHitsProvider<T> missedHitsProvider) {
-    List<T> output = new LinkedList<>();
-    MatchResult result = getAll(keys, clazz);
-
-    output.addAll(result.getHits());
-    if(result.hasMissedKeys()) output.addAll(missedHitsProvider.get(result.getMissedKeys()));
-
-    return output;
   }
 
   public void remove(String key) {


### PR DESCRIPTION
Adding prefix in this function is needed as when there are
missed keys, they usually are with specific prefix only for
the cache and they should be searched in origin without this
prefix