### PR TITLE
pcache/clients/redis: support multi-threaded environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ allprojects {
   targetCompatibility = 1.7
 
   group = 'com.clouway.pcache'
-  version = '0.0.7'
+  version = '0.0.8'
 
   modifyPom {
     project {

--- a/clouway-pcache-client-redis/src/main/java/com/clouway/api/pcache/extensions/redis/RedisCacheManagerFactory.java
+++ b/clouway-pcache-client-redis/src/main/java/com/clouway/api/pcache/extensions/redis/RedisCacheManagerFactory.java
@@ -2,7 +2,8 @@ package com.clouway.api.pcache.extensions.redis;
 
 import com.clouway.api.pcache.CacheManager;
 import com.clouway.api.pcache.NamespaceProvider;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
 
 /**
  * RedisCacheManagerFactory is a CacheManagerFactory.
@@ -58,15 +59,14 @@ public final class RedisCacheManagerFactory {
    * @return the newly created cache manager
    */
   public static CacheManager create(String redisHost, NamespaceProvider namespaceProvider) {
-    Jedis jedis;
-
+    JedisPool pool;
+    
     if (redisHost.contains(":")) {
       String[] parts = redisHost.split(":");
-      jedis = new Jedis(parts[0], Integer.parseInt(parts[1]));
+      pool = new JedisPool(new JedisPoolConfig(), parts[0], Integer.parseInt(parts[1]));
     } else {
-      jedis = new Jedis(redisHost);
+      pool = new JedisPool(redisHost);
     }
-    
-    return new RedisCacheManager(jedis, namespaceProvider);
+    return new RedisCacheManager(pool, namespaceProvider);
   }
 }

--- a/clouway-pcache-client-redis/src/test/java/com/clouway/api/pcache/extensions/redis/RedisCacheManagerTest.java
+++ b/clouway-pcache-client-redis/src/test/java/com/clouway/api/pcache/extensions/redis/RedisCacheManagerTest.java
@@ -22,8 +22,7 @@ public class RedisCacheManagerTest extends CacheManagerContract {
   @ClassRule
   public static GenericContainer redis = new GenericContainer<>("redis:5.0.3-alpine")
           .withExposedPorts(6379);
-
-
+  
   @Test
   public void keysAreNamespaceAware() throws Exception {
     final LinkedList<String> namespaces = new LinkedList<String>();


### PR DESCRIPTION
With this change, the Redis implementation is now safe to be used in a multi-threaded environment as it uses a JedisPool that is a connection pool to Redis.

Now each call to Redis starts with retrieving of connection from that pool and releasing it after the operation completes.

More information for multi-threaded usage could be found at https://github.com/xetorthio/jedis/wiki/Getting-started